### PR TITLE
Update docker-compose and docs to use ghcr docker image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     networks:
       database:
   seizu-dashboard-stats:
-    image: paypay/seizu
+    image: ghcr.io/paypay/seizu
     restart: on-failure
     user: seizu
     environment:
@@ -87,7 +87,7 @@ services:
       stats:
       database:
   seizu-scheduled-queries:
-    image: paypay/seizu
+    image: ghcr.io/paypay/seizu
     restart: on-failure
     user: seizu
     environment:
@@ -115,7 +115,7 @@ services:
       stats:
       database:
   reporting-user-watcher:
-    image: paypay/seizu
+    image: ghcr.io/paypay/seizu
     restart: on-failure
     user: seizu
     environment:
@@ -138,7 +138,7 @@ services:
       stats:
       database:
   seizu:
-    image: paypay/seizu
+    image: ghcr.io/paypay/seizu
     build: .
     user: seizu
     environment:

--- a/docs/root/install/backend.md
+++ b/docs/root/install/backend.md
@@ -8,8 +8,8 @@ If you're just wanting to quickly evaluate or demo Seizu, please see the [quicks
 
 ```bash
 # first setup your environment in an env file, according to the configuration instructions
-docker pull paypay/seizu
-docker run --env-file <your-env-file> paypay/seizu
+docker pull ghcr.io/paypay/seizu:latest
+docker run --env-file <your-env-file> ghcr.io/paypay/seizu:latest
 ```
 
 ## Backend configuration


### PR DESCRIPTION
We're publishing a docker image on release creation in the github docker registry. This change updates the docker-compose and the docs to reference that image.