### PR TITLE
Switch from mui-markdown to markdoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v1
 
+### v1.2.0
+
+* Switch markdown rendering from mui-markdown to markdoc
+* Add support for injecting variables into markdown panels
+* Add support for rendering the value of a query result in markdown, using a ``value`` markdoc function
+
 ### v1.1.0
 
 * Add a version field to the dashboard configuration file

--- a/docs/root/install/dashboard.md
+++ b/docs/root/install/dashboard.md
@@ -203,7 +203,15 @@ To render markdown, use a ``markdown`` panel.
 |-------|-------------|
 | markdown | The markdown to render. |
 | type | The type of panel. ``markdown``, for this panel type. |
+| markdown\_settings | An object of settings specific to pie panels. |
+| markdown\_settings.variables | A list of variables as dictionaries (with keys ``name`` and ``cypher``), used to inject variables into the markdown, for use with markdoc functions. See the [the MarkdownPanelSettingsVariables schema](schema.html#markdownpanelsettingsvariables) for more information. |
 | size | The width of this panel. |
+
+We're using markdoc for markdown rendering, which supports variables, functions, etc. in the markdown. Currently, we support injecting variables from queries, and using those variables in functions.
+
+Currently supported markdoc functions:
+
+* ``value``: Return the value of a specified key from the specified variable. Example (return ``total`` from ``cves``): ``{% value("cves", "total") %}``
 
 #### Example
 
@@ -218,6 +226,13 @@ To render markdown, use a ``markdown`` panel.
 
               ## Recommended action
               Upgrade to log4j 2.17.1 or higher.
+
+              ## Current counts
+              Total: {% value("cves", "total") %}
+            markdown_settings:
+              variables:
+                - name: cves
+                  cypher: log4shell-cves-total
             type: markdown
             size: 12
 ```

--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
     ]
   },
   "dependencies": {
-    "@babel/eslint-parser": "^7.18.2",
     "@emotion/react": "^11.7.0",
     "@emotion/styled": "^11.6.0",
+    "@markdoc/markdoc": "^0.1.2",
     "@mui/icons-material": "^5.2.5",
     "@mui/material": "^5.2.5",
     "@mui/styles": "^5.2.3",
@@ -41,7 +41,6 @@
     "history": "^5.0.0",
     "markdown-to-jsx": "^7.1.7",
     "mui-datatables": "^4.0.0",
-    "mui-markdown": "^0.5.3",
     "prism-react-renderer": "^1.3.1",
     "prop-types": "^15.7.2",
     "query-string": "^7.1.1",
@@ -54,6 +53,7 @@
     "use-neo4j": "^0.3.4"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.18.2",
     "eslint": "^8.2.0",
     "eslint-config-airbnb": "19.0.4",
     "eslint-config-prettier": "^8.5.0",

--- a/reporting/schema/reporting_config.py
+++ b/reporting/schema/reporting_config.py
@@ -112,39 +112,6 @@ class Input:
 
 
 @dataclass
-class BarPanelSettings:
-    legend: Optional[str] = field(
-        metadata={
-            "required": False,
-            "description": (
-                "The type of legend to use; ``row`` or ``column``. If unset,"
-                " then no legend will be used."
-            ),
-        }
-    )
-
-    class Meta:
-        ordered = True
-
-
-@dataclass
-class PiePanelSettings:
-    legend: Optional[str] = field(
-        metadata={
-            "required": False,
-            "description": (
-                "The type of legend to use; ``row`` or ``column``. If unset,"
-                " then no legend will be used, and arc labels will be used"
-                " instead."
-            ),
-        }
-    )
-
-    class Meta:
-        ordered = True
-
-
-@dataclass
 class PanelParam:
     name: str = field(
         metadata={
@@ -181,6 +148,93 @@ class PanelParam:
                     """
                 ],
             },
+        },
+    )
+
+    class Meta:
+        ordered = True
+
+
+@dataclass
+class BarPanelSettings:
+    legend: Optional[str] = field(
+        metadata={
+            "required": False,
+            "description": (
+                "The type of legend to use; ``row`` or ``column``. If unset,"
+                " then no legend will be used."
+            ),
+        }
+    )
+
+    class Meta:
+        ordered = True
+
+
+@dataclass
+class PiePanelSettings:
+    legend: Optional[str] = field(
+        metadata={
+            "required": False,
+            "description": (
+                "The type of legend to use; ``row`` or ``column``. If unset,"
+                " then no legend will be used, and arc labels will be used"
+                " instead."
+            ),
+        }
+    )
+
+    class Meta:
+        ordered = True
+
+
+@dataclass
+class MarkdownPanelSettingsVariables:
+    name: str = field(
+        metadata={
+            "required": True,
+            "description": "The variable name to be used within the markdown.",
+        }
+    )
+
+    cypher: str = field(
+        metadata={
+            "required": True,
+            "description": "A reference to a cypher from the cypher section of the configuration.",
+            "examples": ["cves"],
+        }
+    )
+
+    params: List[PanelParam] = field(
+        default_factory=list,
+        metadata={
+            "required": False,
+            "description": (
+                "A list of parameters to send into the query. The parameters can"
+                " directly have values. Currently does not support inputs."
+            ),
+            "examples": [
+                """
+                .. code-block:: yaml
+
+                  params:
+                    - name: integrityImpact
+                      value: HIGH
+                """
+            ],
+        },
+    )
+
+
+@dataclass
+class MarkdownPanelSettings:
+    variables: List[MarkdownPanelSettingsVariables] = field(
+        default_factory=list,
+        metadata={
+            "required": False,
+            "description": (
+                "Variables to inject into markdoc, for use within the markdown."
+            ),
         },
     )
 
@@ -337,6 +391,23 @@ class Panel:
 
                   pie_settings:
                     legend: column
+                """
+            ],
+        },
+    )
+
+    markdown_settings: Optional[MarkdownPanelSettings] = field(
+        default=None,
+        metadata={
+            "description": "Settings specific to markdown panels.",
+            "examples": [
+                """
+                .. code-block:: yaml
+
+                  markdown_settings:
+                    variables:
+                      - name: cves
+                        cypher: cves-total
                 """
             ],
         },

--- a/schema/reporting-schema.json
+++ b/schema/reporting-schema.json
@@ -2,9 +2,6 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "Dashboard": {
-            "required": [
-                "rows"
-            ],
             "properties": {
                 "rows": {
                     "title": "rows",
@@ -19,14 +16,13 @@
                     }
                 }
             },
+            "required": [
+                "rows"
+            ],
             "type": "object",
             "additionalProperties": false
         },
         "Row": {
-            "required": [
-                "name",
-                "panels"
-            ],
             "properties": {
                 "name": {
                     "title": "name",
@@ -49,13 +45,14 @@
                     }
                 }
             },
+            "required": [
+                "name",
+                "panels"
+            ],
             "type": "object",
             "additionalProperties": false
         },
         "Panel": {
-            "required": [
-                "type"
-            ],
             "properties": {
                 "type": {
                     "title": "_type",
@@ -135,6 +132,17 @@
                         "\n                .. code-block:: markdown\n\n                    ## Affects\n\n                    Versions x.x.x - x.x.x\n\n                    ## Recommended action\n\n                    Upgrade to the latest version of the software.\n                "
                     ]
                 },
+                "markdown_settings": {
+                    "type": "object",
+                    "$ref": "#/definitions/MarkdownPanelSettings",
+                    "description": "Settings specific to markdown panels.",
+                    "examples": [
+                        "\n                .. code-block:: yaml\n\n                  markdown_settings:\n                    variables:\n                      - name: cves\n                        cypher: cves-total\n                "
+                    ],
+                    "default": {
+                        "variables": []
+                    }
+                },
                 "metric": {
                     "title": "metric",
                     "type": [
@@ -209,6 +217,9 @@
                     ]
                 }
             },
+            "required": [
+                "type"
+            ],
             "type": "object",
             "additionalProperties": false
         },
@@ -227,10 +238,57 @@
             "type": "object",
             "additionalProperties": false
         },
-        "PanelParam": {
+        "MarkdownPanelSettings": {
+            "properties": {
+                "variables": {
+                    "title": "variables",
+                    "type": "array",
+                    "description": "Variables to inject into markdoc, for use within the markdown.",
+                    "items": {
+                        "type": "object",
+                        "$ref": "#/definitions/MarkdownPanelSettingsVariables"
+                    }
+                }
+            },
+            "type": "object",
+            "additionalProperties": false
+        },
+        "MarkdownPanelSettingsVariables": {
+            "properties": {
+                "cypher": {
+                    "title": "cypher",
+                    "type": "string",
+                    "description": "A reference to a cypher from the cypher section of the configuration.",
+                    "examples": [
+                        "cves"
+                    ]
+                },
+                "name": {
+                    "title": "name",
+                    "type": "string",
+                    "description": "The variable name to be used within the markdown."
+                },
+                "params": {
+                    "title": "params",
+                    "type": "array",
+                    "description": "A list of parameters to send into the query. The parameters can directly have values. Currently does not support inputs.",
+                    "examples": [
+                        "\n                .. code-block:: yaml\n\n                  params:\n                    - name: integrityImpact\n                      value: HIGH\n                "
+                    ],
+                    "items": {
+                        "type": "object",
+                        "$ref": "#/definitions/PanelParam"
+                    }
+                }
+            },
             "required": [
+                "cypher",
                 "name"
             ],
+            "type": "object",
+            "additionalProperties": false
+        },
+        "PanelParam": {
             "properties": {
                 "input_id": {
                     "title": "input_id",
@@ -259,6 +317,9 @@
                     ]
                 }
             },
+            "required": [
+                "name"
+            ],
             "type": "object",
             "additionalProperties": false
         },
@@ -278,10 +339,6 @@
             "additionalProperties": false
         },
         "Report": {
-            "required": [
-                "name",
-                "rows"
-            ],
             "properties": {
                 "inputs": {
                     "title": "inputs",
@@ -316,15 +373,14 @@
                     }
                 }
             },
+            "required": [
+                "name",
+                "rows"
+            ],
             "type": "object",
             "additionalProperties": false
         },
         "Input": {
-            "required": [
-                "type",
-                "input_id",
-                "label"
-            ],
             "properties": {
                 "type": {
                     "title": "_type",
@@ -390,14 +446,15 @@
                     ]
                 }
             },
+            "required": [
+                "type",
+                "input_id",
+                "label"
+            ],
             "type": "object",
             "additionalProperties": false
         },
         "InputDefault": {
-            "required": [
-                "label",
-                "value"
-            ],
             "properties": {
                 "label": {
                     "title": "label",
@@ -410,14 +467,14 @@
                     "description": "The value for the default."
                 }
             },
+            "required": [
+                "label",
+                "value"
+            ],
             "type": "object",
             "additionalProperties": false
         },
         "ScheduledQuery": {
-            "required": [
-                "cypher",
-                "name"
-            ],
             "properties": {
                 "actions": {
                     "title": "actions",
@@ -496,14 +553,14 @@
                     }
                 }
             },
+            "required": [
+                "cypher",
+                "name"
+            ],
             "type": "object",
             "additionalProperties": false
         },
         "ScheduledQueryAction": {
-            "required": [
-                "action_config",
-                "action_type"
-            ],
             "properties": {
                 "action_config": {
                     "description": "The configuration for the action. See the documentation for the relevant scheduled query module for information about the configuration needed for each action type.",
@@ -524,14 +581,14 @@
                     ]
                 }
             },
+            "required": [
+                "action_config",
+                "action_type"
+            ],
             "type": "object",
             "additionalProperties": false
         },
         "ScheduledQueryParam": {
-            "required": [
-                "name",
-                "value"
-            ],
             "properties": {
                 "name": {
                     "title": "name",
@@ -548,6 +605,10 @@
                     ]
                 }
             },
+            "required": [
+                "name",
+                "value"
+            ],
             "type": "object",
             "additionalProperties": false
         },

--- a/src/components/GlobalStyles.js
+++ b/src/components/GlobalStyles.js
@@ -1,6 +1,6 @@
 import { createStyles, makeStyles } from '@mui/styles';
 
-const useStyles = makeStyles(() =>
+const useStyles = makeStyles((theme) =>
   createStyles({
     '@global': {
       '*': {
@@ -18,21 +18,53 @@ const useStyles = makeStyles(() =>
         width: '100%'
       },
       a: {
+        color: theme.palette.primary.main,
         textDecoration: 'none'
       },
       '#root': {
         height: '100%',
         width: '100%'
       },
-      '.mui-markdown-ol': {
+      // Update CSS for markdoc, which places nodes under "article" nodes
+      'article ol': {
         paddingLeft: 40,
         paddingTop: 10,
         paddingBottom: 10
       },
-      '.mui-markdown-ul': {
+      'article ul': {
         paddingLeft: 40,
         paddingTop: 10,
         paddingBottom: 10
+      },
+      'article h1': {
+        fontWeight: 500,
+        fontSize: 29,
+        letterSpacing: '-0.24px'
+      },
+      'article h2': {
+        fontWeight: 500,
+        fontSize: 24,
+        letterSpacing: '-0.06px'
+      },
+      'article h3': {
+        fontWeight: 500,
+        fontSize: 20,
+        letterSpacing: '-0.05px'
+      },
+      'article h4': {
+        fontWeight: 500,
+        fontSize: 16,
+        letterSpacing: '-0.05px'
+      },
+      'article h5': {
+        fontWeight: 500,
+        fontSize: 16,
+        letterSpacing: '-0.05px'
+      },
+      'article h6': {
+        fontWeight: 500,
+        fontSize: 14,
+        letterSpacing: '-0.05px'
       }
     }
   })

--- a/src/components/reports/Markdown.js
+++ b/src/components/reports/Markdown.js
@@ -1,0 +1,79 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Markdoc from '@markdoc/markdoc';
+// eslint-disable-next-line  import/no-extraneous-dependencies
+import neo4j from 'neo4j-driver';
+import { Neo4jContext } from 'use-neo4j';
+
+export default function Markdown({ markdown, markdownSettings, queries }) {
+  const { driver, database } = React.useContext(Neo4jContext);
+  const [variableData, setVariableData] = React.useState({});
+
+  React.useEffect(() => {
+    markdownSettings.variables.forEach((variable) => {
+      const session = driver.session({
+        database,
+        defaultAccessMode: neo4j.session.READ
+      });
+      const params = {};
+      variable.params.forEach((param) => {
+        params[param.name] = param.value;
+      });
+      const query = queries[variable.cypher];
+      session
+        .run(query, params)
+        .then((result) => {
+          setVariableData({
+            ...variableData,
+            [variable.name]: { records: result.records }
+          });
+
+          session.close();
+        })
+        .catch((error) => {
+          setVariableData({
+            ...variableData,
+            [variable.name]: { records: {}, error }
+          });
+          console.log(error);
+
+          session.close();
+        });
+    });
+  }, [markdownSettings]);
+
+  const value = {
+    transform(parameters) {
+      const [variable, key] = Object.values(parameters);
+
+      try {
+        const ret = variableData[variable].records[0].get(key);
+        if (neo4j.isInt(ret)) {
+          return neo4j.int(ret).toNumber();
+        }
+        return ret;
+      } catch (e) {
+        return '';
+      }
+    }
+  };
+
+  const config = {
+    tags: {},
+    nodes: {},
+    variables: variableData,
+    functions: {
+      value
+    }
+  };
+  const ast = Markdoc.parse(markdown);
+  const content = Markdoc.transform(ast, config);
+
+  return Markdoc.renderers.react(content, React, {});
+}
+
+Markdown.propTypes = {
+  markdown: PropTypes.string,
+  markdownSettings: PropTypes.object,
+  queries: PropTypes.object
+};

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -9,7 +9,6 @@ import {
   Typography
 } from '@mui/material';
 import Loader from 'react-loader-spinner';
-import MuiMarkdown from 'mui-markdown';
 
 import { ConfigContext } from 'src/config.context';
 import CypherBar from 'src/components/reports/CypherBar';
@@ -19,6 +18,7 @@ import CypherCount from 'src/components/reports/CypherCount';
 import CypherTable from 'src/components/reports/CypherTable';
 import CypherVerticalTable from 'src/components/reports/CypherVerticalTable';
 import OncallTable from 'src/components/reports/OncallTable';
+import Markdown from 'src/components/reports/Markdown';
 
 function Dashboard() {
   const { config } = useContext(ConfigContext);
@@ -121,37 +121,11 @@ function Dashboard() {
         );
       } else if (item.type === 'markdown') {
         itemComponent = (
-          <MuiMarkdown
-            overrides={{
-              h1: {
-                component: 'h2'
-              },
-              h2: {
-                component: 'h3'
-              },
-              h3: {
-                component: 'h4'
-              },
-              h4: {
-                component: 'h5'
-              },
-              h5: {
-                component: 'h6'
-              },
-              ol: {
-                props: {
-                  className: 'mui-markdown-ol'
-                }
-              },
-              ul: {
-                props: {
-                  className: 'mui-markdown-ul'
-                }
-              }
-            }}
-          >
-            {item.markdown}
-          </MuiMarkdown>
+          <Markdown
+            markdown={item.markdown}
+            markdownSettings={item.markdown_settings}
+            queries={queries}
+          />
         );
       }
 

--- a/src/pages/Reports.js
+++ b/src/pages/Reports.js
@@ -11,7 +11,6 @@ import {
 } from '@mui/material';
 import Loader from 'react-loader-spinner';
 import Error from '@mui/icons-material/Error';
-import MuiMarkdown from 'mui-markdown';
 
 import { ConfigContext } from 'src/config.context';
 import { getQueryStringValue } from 'src/components/QueryString';
@@ -25,6 +24,7 @@ import CypherAutocomplete from 'src/components/reports/CypherAutocomplete';
 import FreeTextInput from 'src/components/reports/FreeTextInput';
 import CypherOncallTable from 'src/components/reports/CypherOncallTable';
 import OncallTable from 'src/components/reports/OncallTable';
+import Markdown from 'src/components/reports/Markdown';
 
 function Reports() {
   const { id } = useParams();
@@ -261,37 +261,11 @@ function Reports() {
         }
       } else if (item.type === 'markdown') {
         itemComponent = (
-          <MuiMarkdown
-            overrides={{
-              h1: {
-                component: 'h2'
-              },
-              h2: {
-                component: 'h3'
-              },
-              h3: {
-                component: 'h4'
-              },
-              h4: {
-                component: 'h5'
-              },
-              h5: {
-                component: 'h6'
-              },
-              ol: {
-                props: {
-                  className: 'mui-markdown-ol'
-                }
-              },
-              ul: {
-                props: {
-                  className: 'mui-markdown-ul'
-                }
-              }
-            }}
-          >
-            {item.markdown}
-          </MuiMarkdown>
+          <Markdown
+            markdown={item.markdown}
+            markdownSettings={item.markdown_settings}
+            queries={queries}
+          />
         );
       }
       let size;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1577,6 +1577,11 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
+"@markdoc/markdoc@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@markdoc/markdoc/-/markdoc-0.1.2.tgz#401c7536ed1fd33951458747d2d74f217241e142"
+  integrity sha512-3p+JTC1A0eqBdrl2UOIRoy+FLKtG1mh81R3Zzdm7FJiQIMt2mJmqmVQNDf3Md62G9rTtbj0ZuxlEattMbaslbw==
+
 "@mui/base@5.0.0-alpha.83":
   version "5.0.0-alpha.83"
   resolved "https://registry.yarnpkg.com/@mui/base/-/base-5.0.0-alpha.83.tgz#8ac60dc7315f8ae001233e8e10398e31833625bd"
@@ -6786,11 +6791,6 @@ mui-datatables@^4.0.0:
     react-sortable-tree-patch-react-17 "^2.9.0"
     react-to-print "^2.8.0"
     tss-react "^3.6.0"
-
-mui-markdown@^0.5.3:
-  version "0.5.3"
-  resolved "https://registry.yarnpkg.com/mui-markdown/-/mui-markdown-0.5.3.tgz#b50e4c43825cf5701a00279340c8b86e7115aa39"
-  integrity sha512-hSs2XhxMHxFrwyFbmRg9r1MonBaVy04aoY0fG2e525MBIHkIPTy/JIauH0WRZ12i7bwg5dh+QNn5gkb97VoKog==
 
 multicast-dns@^7.2.4:
   version "7.2.5"


### PR DESCRIPTION
This change switches from mui-markdown to markdoc for rendering markdown. Markdoc supports variables, functions, etc, as extensions to markdown, using simple templating that can be extended specifically for our needs.

As part of this switchover, this change also makes it possible to inject variables into markdown rendering, and supports rendering values from those queries using a markdoc function.